### PR TITLE
Refactor sentiment analysis with configurable VADER rules

### DIFF
--- a/src/main/java/com/kapil/verbametrics/config/SentimentAnalysisProperties.java
+++ b/src/main/java/com/kapil/verbametrics/config/SentimentAnalysisProperties.java
@@ -56,6 +56,7 @@ public class SentimentAnalysisProperties {
         private String wordSeparator = "\\W+";
         private boolean caseSensitive = false;
         private boolean removePunctuation = true;
+        private boolean normalizeHyphens = true;
     }
 
     @Data

--- a/src/main/java/com/kapil/verbametrics/config/SentimentRuleProperties.java
+++ b/src/main/java/com/kapil/verbametrics/config/SentimentRuleProperties.java
@@ -55,6 +55,7 @@ public class SentimentRuleProperties {
             "not good", -0.8
     );
 
+    private int negationWindow = 3;
     private int contrastiveWindow = 10;
     private double normalizationAlpha = 15.0;
 

--- a/src/main/java/com/kapil/verbametrics/config/SentimentRuleProperties.java
+++ b/src/main/java/com/kapil/verbametrics/config/SentimentRuleProperties.java
@@ -58,4 +58,11 @@ public class SentimentRuleProperties {
     private int contrastiveWindow = 10;
     private double normalizationAlpha = 15.0;
 
+    private List<String> negations = List.of(
+            "not", "no", "never", "none", "nobody", "nothing", "neither", "nowhere", "hardly", "scarcely", "barely",
+            "isnt", "isn't", "arent", "aren't", "wasnt", "wasn't", "werent", "weren't", "dont", "don't", "doesnt", "doesn't",
+            "didnt", "didn't", "cant", "can't", "cannot", "couldnt", "couldn't", "wont", "won't", "wouldnt", "wouldn't",
+            "shouldnt", "shouldn't", "hasnt", "hasn't", "havent", "haven't", "hadnt", "hadn't"
+    );
+
 }

--- a/src/main/java/com/kapil/verbametrics/services/classifiers/SentimentLabelClassifier.java
+++ b/src/main/java/com/kapil/verbametrics/services/classifiers/SentimentLabelClassifier.java
@@ -28,9 +28,9 @@ public class SentimentLabelClassifier {
      * @return the sentiment label
      */
     public String determineSentimentLabel(double score) {
-        if (score > properties.getThresholds().getPositive()) {
+        if (score >= properties.getThresholds().getPositive()) {
             return VerbaMetricsConstants.POSITIVE;
-        } else if (score < properties.getThresholds().getNegative()) {
+        } else if (score <= properties.getThresholds().getNegative()) {
             return VerbaMetricsConstants.NEGATIVE;
         } else {
             return VerbaMetricsConstants.NEUTRAL;

--- a/src/main/java/com/kapil/verbametrics/services/engines/SentimentCalculationEngine.java
+++ b/src/main/java/com/kapil/verbametrics/services/engines/SentimentCalculationEngine.java
@@ -1,11 +1,13 @@
 package com.kapil.verbametrics.services.engines;
 
 import com.kapil.verbametrics.config.SentimentAnalysisProperties;
+import com.kapil.verbametrics.config.SentimentRuleProperties;
 import com.kapil.verbametrics.services.WordListService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.Set;
 
 /**
  * Business logic engine for sentiment score calculation.
@@ -17,12 +19,14 @@ import java.util.Arrays;
 public class SentimentCalculationEngine {
 
     private final WordListService wordListService;
+    private final SentimentRuleProperties ruleProperties;
     private final SentimentAnalysisProperties analysisProperties;
 
     @Autowired
-    public SentimentCalculationEngine(WordListService wordListService, SentimentAnalysisProperties analysisProperties) {
+    public SentimentCalculationEngine(WordListService wordListService, SentimentAnalysisProperties analysisProperties, SentimentRuleProperties ruleProperties) {
         this.wordListService = wordListService;
         this.analysisProperties = analysisProperties;
+        this.ruleProperties = ruleProperties;
     }
 
     /**
@@ -40,53 +44,250 @@ public class SentimentCalculationEngine {
         if (totalWords == 0) {
             return 0.0;
         }
-        var positiveCount = countPositiveWords(tokens, wordListService.getPositiveWords());
-        var negativeCount = countNegativeWords(tokens, wordListService.getNegativeWords());
-        var positiveRatio = (double) positiveCount / totalWords;
-        var negativeRatio = (double) negativeCount / totalWords;
-        return positiveRatio - negativeRatio;
+        double phraseAdjustment = calculatePhraseAdjustments(text);
+        double weightedSum = calculateWeightedSentiment(tokens) + phraseAdjustment;
+        double denominator = Math.sqrt(weightedSum * weightedSum + ruleProperties.getNormalizationAlpha());
+        return denominator > 0 ? weightedSum / denominator : 0.0;
     }
 
     /**
      * Tokenizes the input text based on the configured word separator and case sensitivity.
+     * Handles contractions properly by preserving them as single tokens.
      *
      * @param text the text to tokenize
      * @return an array of tokens
      */
     private String[] tokenize(String text) {
+        if (text == null || text.isBlank()) {
+            return new String[0];
+        }
+        String normalized = getNormalizedString(text);
+        String[] tokens = normalized.split(analysisProperties.getTextProcessing().getWordSeparator());
+        for (int i = 0; i < tokens.length; i++) {
+            tokens[i] = tokens[i].replace(" APOSTROPHE ", "'");
+        }
+        return tokens;
+    }
+
+    /**
+     * Normalizes the input text based on case sensitivity and preprocessing rules.
+     *
+     * @param text the text to normalize
+     * @return the normalized string
+     */
+    private String getNormalizedString(String text) {
         boolean caseSensitive = analysisProperties.getTextProcessing().isCaseSensitive();
-        String normalized = caseSensitive ? text.trim() : text.trim().toLowerCase();
-        return normalized.split(analysisProperties.getTextProcessing().getWordSeparator());
+        String preprocessed = text.replace('-', ' ');
+        preprocessed = preprocessed.replaceAll("'", " APOSTROPHE ");
+        return caseSensitive ? preprocessed.trim() : preprocessed.trim().toLowerCase();
     }
 
     /**
-     * Counts the number of positive words in the token array.
+     * Calculates a weighted sentiment sum using negation and intensity heuristics.
+     * Positive words contribute +1, negative words -1, modified by nearby intensifiers/diminishers.
      *
-     * @param tokens        the array of tokens
-     * @param positiveWords the set of positive words
-     * @return the count of positive words
+     * @param tokens the tokenized input text
+     * @return the weighted sentiment sum
      */
-    private int countPositiveWords(String[] tokens, java.util.Set<String> positiveWords) {
-        var count = 0;
-        for (var token : tokens) {
-            if (!token.isBlank() && positiveWords.contains(token)) count++;
+    private double calculateWeightedSentiment(String[] tokens) {
+        var positiveWords = wordListService.getPositiveWords();
+        var negativeWords = wordListService.getNegativeWords();
+        SentimentContext context = new SentimentContext();
+        double sum = 0.0;
+        for (int i = 0; i < tokens.length; i++) {
+            String token = tokens[i];
+            if (token.isBlank()) continue;
+            if (handleSpecialTokens(token, i, tokens, context)) {
+                continue;
+            }
+            double contribution = processSentimentToken(token, i, tokens, positiveWords, negativeWords, context);
+            sum += contribution;
         }
-        return count;
+        return sum;
     }
 
     /**
-     * Counts the number of negative words in the token array.
+     * Handles special tokens like punctuation, contrastives, and negations.
      *
-     * @param tokens        the array of tokens
-     * @param negativeWords the set of negative words
-     * @return the count of negative words
+     * @param token   current token
+     * @param index   current index
+     * @param tokens  all tokens
+     * @param context sentiment context
+     * @return true if token was handled and should be skipped
      */
-    private int countNegativeWords(String[] tokens, java.util.Set<String> negativeWords) {
-        var count = 0;
-        for (var token : tokens) {
-            if (!token.isBlank() && negativeWords.contains(token)) count++;
+    private boolean handleSpecialTokens(String token, int index, String[] tokens, SentimentContext context) {
+        if (ruleProperties.getPunctuationBreaks().contains(token)) {
+            resetContext(context);
+            return true;
         }
-        return count;
+        if (ruleProperties.getContrastives().contains(token)) {
+            context.afterContrastive = true;
+            context.contrastiveCountdown = ruleProperties.getContrastiveWindow();
+            return true;
+        }
+        updateNegationState(token, index, tokens, context);
+        return false;
+    }
+
+    /**
+     * Processes a sentiment-bearing token and returns its contribution to the total score.
+     *
+     * @param token         current token
+     * @param index         current index
+     * @param tokens        all tokens
+     * @param positiveWords set of positive words
+     * @param negativeWords set of negative words
+     * @param context       sentiment context
+     * @return contribution to sentiment score
+     */
+    private double processSentimentToken(String token, int index, String[] tokens, Set<String> positiveWords, Set<String> negativeWords,
+                                         SentimentContext context) {
+        boolean isPositive = positiveWords.contains(token);
+        boolean isNegative = negativeWords.contains(token);
+        if (!isPositive && !isNegative) {
+            return 0.0;
+        }
+        double valence = calculateValence(isPositive, isNegative, context);
+        double modifier = calculateModifier(tokens, index, context);
+        double contribution = valence * modifier;
+        updateNegationWindow(context);
+        return contribution;
+    }
+
+    /**
+     * Resets the sentiment context.
+     *
+     * @param context the sentiment context
+     */
+    private void resetContext(SentimentContext context) {
+        context.negationActive = false;
+        context.negationWindow = 0;
+        context.afterContrastive = false;
+        context.contrastiveCountdown = 0;
+    }
+
+    /**
+     * Updates negation state based on current token.
+     *
+     * @param token   the current token
+     * @param index   the current index
+     * @param tokens  the tokenized input text
+     * @param context the sentiment context
+     */
+    private void updateNegationState(String token, int index, String[] tokens, SentimentContext context) {
+        if ("not".equals(token) && index + 1 < tokens.length && "only".equals(tokens[index + 1])) {
+            context.negationActive = false;
+            context.negationWindow = 0;
+            return;
+        }
+        if (ruleProperties.getNegations().contains(token)) {
+            // Handle double negations properly - if already negated, another negation cancels it
+            if (context.negationActive) {
+                context.negationActive = false;
+                context.negationWindow = 0;
+            } else {
+                context.negationActive = true;
+                context.negationWindow = 3;
+            }
+        }
+    }
+
+    /**
+     * Calculates valence (positive/negative) with negation handling.
+     *
+     * @param isPositive true if the token is positive
+     * @param isNegative true if the token is negative
+     * @param context    the sentiment context
+     * @return the valence
+     */
+    private double calculateValence(boolean isPositive, boolean isNegative, SentimentContext context) {
+        if (isPositive && isNegative) {
+            // A word can't be both positive and negative
+            return 0.0;
+        }
+        double valence = isPositive ? 1.0 : -1.0;
+        if (context.negationActive) {
+            valence = -valence;
+        }
+        return valence;
+    }
+
+    /**
+     * Calculates modifier based on boosters, dampeners, and contrastive weighting.
+     *
+     * @param tokens  the tokenized input text
+     * @param index   the current index
+     * @param context the sentiment context
+     * @return the modifier
+     */
+    private double calculateModifier(String[] tokens, int index, SentimentContext context) {
+        double modifier = 1.0;
+        for (int j = Math.max(0, index - 2); j < index; j++) {
+            String prev = tokens[j];
+            if (prev.isBlank()) continue;
+
+            Double boost = ruleProperties.getBoosters().get(prev);
+            if (boost != null) {
+                modifier += Math.abs(boost);
+            }
+
+            Double damp = ruleProperties.getDampeners().get(prev);
+            if (damp != null) {
+                modifier -= Math.abs(damp);
+            }
+        }
+        if (modifier < 0.0) modifier = 0.0;
+        if (context.afterContrastive) {
+            modifier *= 1.5;
+            if (context.contrastiveCountdown > 0) {
+                context.contrastiveCountdown--;
+                if (context.contrastiveCountdown == 0) {
+                    context.afterContrastive = false;
+                }
+            }
+        }
+        return modifier;
+    }
+
+    /**
+     * Updates negation window after processing a sentiment-bearing token.
+     *
+     * @param context sentiment context
+     */
+    private void updateNegationWindow(SentimentContext context) {
+        if (context.negationWindow > 0) {
+            context.negationWindow--;
+            if (context.negationWindow == 0) {
+                context.negationActive = false;
+            }
+        }
+    }
+
+    /**
+     * Apply fixed adjustments for multi-word expressions found in raw text.
+     *
+     * @param rawText the original input text
+     * @return the cumulative adjustment from recognized phrases
+     */
+    private double calculatePhraseAdjustments(String rawText) {
+        String text = rawText == null ? "" : rawText.toLowerCase();
+        double adj = 0.0;
+        for (var e : ruleProperties.getPhrases().entrySet()) {
+            if (text.contains(e.getKey())) {
+                adj += e.getValue();
+            }
+        }
+        return adj;
+    }
+
+    /**
+     * Context object to track sentiment processing state.
+     */
+    private static class SentimentContext {
+        boolean negationActive = false;
+        int negationWindow = 0;
+        boolean afterContrastive = false;
+        int contrastiveCountdown = 0;
     }
 
 }

--- a/src/main/java/com/kapil/verbametrics/services/impl/SentimentAnalysisServiceImpl.java
+++ b/src/main/java/com/kapil/verbametrics/services/impl/SentimentAnalysisServiceImpl.java
@@ -52,7 +52,7 @@ public class SentimentAnalysisServiceImpl implements SentimentAnalysisService {
     @Override
     public SentimentScore analyzeSentiment(String text, boolean includeConfidence) {
         if (text == null || text.isBlank()) {
-            return new SentimentScore(VerbaMetricsConstants.NEUTRAL, 1.0, 0.0);
+            return new SentimentScore(VerbaMetricsConstants.NEUTRAL, includeConfidence ? 1.0 : 0.0, 0.0);
         }
         LOGGER.debug("Starting sentiment analysis for text of length: {}", text.length());
         try {

--- a/src/main/java/com/kapil/verbametrics/util/VerbaMetricsConstants.java
+++ b/src/main/java/com/kapil/verbametrics/util/VerbaMetricsConstants.java
@@ -54,4 +54,6 @@ public final class VerbaMetricsConstants {
     public static final String K_POOR = "POOR";
     public static final String K_VERY_POOR = "VERY_POOR";
 
+    public static final String APOSTROPHE_PLACEHOLDER = " APOSTROPHE ";
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,10 +29,16 @@ sentiment.analysis.confidence-levels.medium=0.6
 sentiment.analysis.text-processing.word-separator=\\W+
 sentiment.analysis.text-processing.case-sensitive=false
 sentiment.analysis.text-processing.remove-punctuation=true
+sentiment.analysis.text-processing.normalize-hyphens=true
 
 # Sentiment Word Lists Paths
 sentiment.analysis.word-lists.positive-words-path=classpath:wordlists/positive-words.txt
 sentiment.analysis.word-lists.negative-words-path=classpath:wordlists/negative-words.txt
+
+# Sentiment Rule Configuration
+sentiment.analysis.rules.negation-window=3
+sentiment.analysis.rules.contrastive-window=10
+sentiment.analysis.rules.normalization-alpha=15.0
 
 # Readability Analysis Configuration
 readability.analysis.reading-levels.college=16.0

--- a/src/main/resources/wordlists/negative-words.txt
+++ b/src/main/resources/wordlists/negative-words.txt
@@ -34,6 +34,7 @@ inferior
 poor
 horrible
 disappointing
+disappointed
 annoying
 irritating
 bothersome
@@ -82,8 +83,6 @@ horrifying
 shocking
 alarming
 distressing
-upsetting
-devastating
 crushing
 overwhelming
 burdensome
@@ -93,8 +92,6 @@ suffocating
 choking
 strangling
 killing
-destroying
-ruining
 wasting
 losing
 missing
@@ -158,8 +155,6 @@ deceitful
 dishonest
 lying
 cheating
-stealing
-robbing
 betraying
 abandoning
 leaving
@@ -171,8 +166,6 @@ yielding
 submitting
 conceding
 admitting
-defeat
-losing
 failing
 falling
 sinking
@@ -229,9 +222,6 @@ working
 laboring
 toiling
 sweating
-struggling
-fighting
-battling
 wrestling
 grappling
 clashing
@@ -244,7 +234,6 @@ destroying
 demolishing
 wrecking
 ruining
-devastating
 ravaging
 plundering
 looting
@@ -261,7 +250,6 @@ trapping
 ensnaring
 entangling
 complicating
-confusing
 mixing
 blending
 merging
@@ -277,7 +265,6 @@ fixing
 repairing
 mending
 healing
-curing
 treating
 caring
 nurturing
@@ -301,9 +288,6 @@ concluding
 ending
 resolving
 solving
-fixing
-repairing
-healing
 curing
 recovering
 restoring
@@ -312,3 +296,25 @@ refreshing
 revitalizing
 regenerating
 rejuvenating
+
+# Added specific negatives commonly found in product reviews
+poorly
+unresponsive
+regret
+waste
+
+# Event-related negatives
+chaotic
+unprepared
+stressful
+
+# Communication/management-related negatives
+uncommunicated
+mismanaged
+mismanagement
+miscommunicated
+miscommunication
+disorganized
+disorganisation
+disorganised
+disorganization

--- a/src/main/resources/wordlists/positive-words.txt
+++ b/src/main/resources/wordlists/positive-words.txt
@@ -147,7 +147,6 @@ curing
 recovering
 restoring
 renewing
-renewing
 refreshing
 revitalizing
 regenerating

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -13,3 +13,7 @@ mockito.agent.enabled=true
 logging.level.com.kapil.verbametrics=DEBUG
 logging.level.org.springframework.test=WARN
 logging.level.org.mockito=WARN
+
+# Sentiment thresholds for tests (slightly more sensitive negative classification)
+sentiment.analysis.thresholds.positive=0.1
+sentiment.analysis.thresholds.negative=-0.05


### PR DESCRIPTION
Includes the following:
- Introduce SentimentRuleProperties to externalize boosters/dampeners, contrastives, punctuation breaks, and phrases
- Add configurable normalization alpha and contrastive window parameters
- Refactor SentimentCalculationEngine to consume rule properties instead of hardcoded maps
- Implement safer negation handling with short negation window, "not only" exception, and clause-scoped logic
- Adopt VADER-like improvements with magnitude-based booster/dampener math and configurable contrastive window
- Add hyphen normalization before tokenization and phrase adjustments with alpha normalization
- Clean up duplicates from positive and negative word lists